### PR TITLE
사용하지 않은 free variables이 closure에 포함되지 않도록 수정

### DIFF
--- a/src/CSEncTerm.hs
+++ b/src/CSEncTerm.hs
@@ -44,7 +44,7 @@ prTerm :: EncTerm -> String
 prTerm (Const i) = show i 
 prTerm (Var x) = x
 prTerm (Clo f vs) =
-    "Clo(" ++ f ++ ", " ++ seqToStr (map prTerm vs) ++ ")"
+    "Clo(" ++ f ++ ", {" ++ seqToStr (map prTerm vs) ++ "})"
 -- prTerm (Lam loc xs m) = 
 --     "lam^" ++ locToStr loc ++ "(" ++ seqToStr xs ++ ")." ++ prTerm m
 prTerm (App f ws) = 

--- a/src/CSStaTerm.hs
+++ b/src/CSStaTerm.hs
@@ -53,7 +53,7 @@ prTerm :: StaTerm -> String
 prTerm (Const i) = show i 
 prTerm (Var x) = x
 prTerm (Clo f vs) =
-    "Clo(" ++ f ++ ", " ++ seqToStr (map prTerm vs) ++ ")"
+    "Clo(" ++ f ++ ", {" ++ seqToStr (map prTerm vs) ++ "})"
 -- prTerm (Lam loc xs m) = 
 --     "lam^" ++ locToStr loc ++ "(" ++ seqToStr xs ++ ")." ++ prTerm m
 prTerm (App f ws) = 

--- a/src/CompCSEncTerm.hs
+++ b/src/CompCSEncTerm.hs
@@ -14,11 +14,12 @@ comp i (RT.Const c) zs = (i, CT.Const c, [], [])
 comp i (RT.Var x) zs = (i, CT.Var x, [], [])
 comp i (RT.Lam loc xs m) zs = 
     let (j, m', fs_c, fs_s) = comp i m (zs ++ xs)
-        closedFun = (zs, loc, xs, m')
+        closedFun = (fvs, loc, xs, m')
         f = "f" ++ show j
         fs_c' = if loc == Client then fs_c ++ [(f, closedFun)] else fs_c
         fs_s' = if loc == Server then fs_s ++ [(f, closedFun)] else fs_s
-    in  (j+1, CT.Clo f (map CT.Var zs), fs_c', fs_s')
+        fvs = fv (RT.Lam loc xs m)  -- replace zs with fvs
+    in  (j+1, CT.Clo f (map CT.Var fvs), fs_c', fs_s')
 comp i (RT.App fn args) zs = 
     let (j1, csfn, fs_c, fs_s) = comp i fn zs
         (j2, csargs, fs_cs, fs_ss) = compList j1 args zs

--- a/src/CompCSStaTerm.hs
+++ b/src/CompCSStaTerm.hs
@@ -14,11 +14,12 @@ comp i (RT.Const c) zs = (i, CT.Const c, [], [])
 comp i (RT.Var x) zs = (i, CT.Var x, [], []) 
 comp i (RT.Lam loc xs m) zs =
     let (j, m', fs_c, fs_s) = comp i m (zs ++ xs)
-        closedFun = (zs, loc, xs, m')
+        closedFun = (fvs, loc, xs, m')
         f = "f" ++ show j
         fs_c' = if loc == Client then fs_c ++ [(f, closedFun)] else fs_c
         fs_s' = if loc == Server then fs_s ++ [(f, closedFun)] else fs_s
-    in  (j+1, CT.Clo f (map CT.Var zs), fs_c', fs_s')
+        fvs = fv (RT.Lam loc xs m)
+    in  (j+1, CT.Clo f (map CT.Var fvs), fs_c', fs_s')
 comp i (RT.App fn args) zs = 
     let (j1, csfn, fs_c, fs_s) = comp i fn zs
         (j2, csargs, fs_cs, fs_ss) = compList j1 args zs

--- a/src/RPCEncTerm.hs
+++ b/src/RPCEncTerm.hs
@@ -1,5 +1,6 @@
-module RPCEncTerm(EncTerm(..), EncValue, subst, substs, prTerm) where
+module RPCEncTerm(EncTerm(..), EncValue, subst, substs, fv, prTerm) where
 
+import Data.List
 
 import Term(Location(..),locToStr,seqToStr)
 
@@ -37,6 +38,16 @@ substs :: EncTerm -> [String] -> [EncValue] -> EncTerm
 substs m [] [] = m 
 substs m (x:xs) (v:vs) = substs (subst m x v) xs vs 
 substs m _ _ = error ("Error in substs: the lengths of vars and vals are different")
+
+--
+fv :: EncTerm -> [String]
+fv m@(Const i) = []
+fv m@(Var y) = [y]
+fv m@(Lam loc xs mbody) = nub (fv mbody) \\ xs
+fv m@(Call f ws) = nub (concat (map fv (f:ws)))
+fv m@(Req f ws) = nub (concat (map fv (f:ws)))
+fv m@(App f ws) = nub (concat (map fv (f:ws)))
+fv m@(Let x m1 m2) = nub (fv m1 `union` (nub (fv m2) \\ [x]))
 
 --
 prTerm :: EncTerm -> String 

--- a/src/RPCStaTerm.hs
+++ b/src/RPCStaTerm.hs
@@ -1,6 +1,6 @@
-module RPCStaTerm(StaTerm(..), StaValue, subst, substs, prTerm) where
+module RPCStaTerm(StaTerm(..), StaValue, subst, substs, fv, prTerm) where
 
-
+import Data.List
 import Term(Location(..),locToStr,seqToStr)
 
 --
@@ -37,6 +37,17 @@ substs :: StaTerm -> [String] -> [StaValue] -> StaTerm
 substs m [] [] = m 
 substs m (x:xs) (v:vs) = substs (subst m x v) xs vs 
 substs m _ _ = error ("Error in substs: the lengths of vars and vals are different")
+
+--
+fv :: StaTerm -> [String]
+fv m@(Const i) = []
+fv m@(Var y) = [y]
+fv m@(Lam loc xs mbody) = nub (fv mbody) \\ xs
+fv m@(Call f ws) = nub (concat (map fv (f:ws)))
+fv m@(Ret v) = fv v
+fv m@(Req f ws) = nub (concat (map fv (f:ws)))
+fv m@(App f ws) = nub (concat (map fv (f:ws)))
+fv m@(Let x m1 m2) = nub (fv m1 `union` (nub (fv m2) \\ [x]))
 
 --
 prTerm :: StaTerm -> String 


### PR DESCRIPTION
사용하지 않은 free variables이 closure에 포함되지 않도록 수정.
closure를 출력하면 free variable을 { }로 감싸도록 수정
@Kim-Gayoung